### PR TITLE
initial version of cat-boot-cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,7 @@ See [`/cat-boot-thymeleaf`](/cat-boot-thymeleaf)
 ## PDF Reporting engine
 
 See [`/cat-boot-report-pdf`](/cat-boot-report-pdf)
+
+## Redis-Clustering
+
+See [`/cat-boot-cluster`](/cat-boot-cluster)

--- a/cat-boot-cluster/README.md
+++ b/cat-boot-cluster/README.md
@@ -1,0 +1,43 @@
+# Redis session clustering autoconfiguration
+
+This module integrates Spring-Session (http://projects.spring.io/spring-session/) and configures it with useful defaults.
+It also integrates Spring-Boot-Actuator (https://spring.io/guides/gs/actuator-service/) since when you go to a clustering setup, you will sooner or later need this kind of visibility into your application.
+
+## Features
+
+### Safe Session Deserialization
+
+By default deserialization errors of session objects will stop your users in their tracks. This may happen more often than you think and is a very sneaky problem to have.
+This problem will typically hit you when you upgrade some dependency which exposes classes which are used within the session object. One example is spring-security.
+Upgrading spring-security can lead to all your user sessions becoming unusable.
+By itself this wouldn't be so bad, but in most configuratoins your users would end up seeing some error page, and maybe even be unable to log in unless they manage to destroy their session-cookie.
+
+The autoconfiguration in this module takes care of this and will simply destroy these invalid sessions, all your users will see is that they have to login again.
+
+
+### Cluster-Metrics
+
+It configures metric-publishing to redis and aggregation of metrics. This means in a clustered setup you will see aggregate counts of your monitoring values.
+
+## Integration
+
+With Gradle
+
+```
+runtime('cc.catalysts.boot:cat-boot-cluster:' + catBootVersion)
+```
+
+## Configuration
+
+It comes with with an AutoConfiguration,
+so if you are using Spring Boot's @EnableAutoConfiguration, then the configuration will be picked up automatically.
+
+The following configuration parameters are available (here with their default values):
+
+```ini
+# Set this property to true to disable publishing metrics to redis.
+clustermetrics.disabled = false
+
+```
+
+Furthermore take a look at the configuration options for spring-boot-actuator.

--- a/cat-boot-cluster/build.gradle
+++ b/cat-boot-cluster/build.gradle
@@ -1,0 +1,31 @@
+apply plugin: 'java'
+apply plugin: 'propdeps'
+apply plugin: 'propdeps-maven'
+apply plugin: 'propdeps-idea'
+
+apply plugin: 'spring-boot'
+
+bootRepackage {
+    enabled = false
+}
+
+dependencies {
+    compile('org.slf4j:slf4j-api')
+    compile('org.springframework.boot:spring-boot')
+    compile('org.springframework.boot:spring-boot-autoconfigure')
+    compile('org.springframework.boot:spring-boot-starter-actuator')
+    // spring session clustering support
+    compile('org.springframework.boot:spring-boot-starter-redis')
+    compile('org.springframework.session:spring-session-data-redis')
+
+    provided('javax.servlet:javax.servlet-api')
+    provided('org.springframework:spring-web')
+
+    testCompile( 'junit:junit:4.11')
+    testCompile( 'org.mockito:mockito-core')
+    testCompile( 'org.springframework:spring-test')
+    testCompile( 'commons-logging:commons-logging:1.2')
+
+}
+
+compileJava.dependsOn processResources

--- a/cat-boot-cluster/src/main/java/cc/catalysts/boot/cluster/config/CatBootClusterAutoconfiguration.java
+++ b/cat-boot-cluster/src/main/java/cc/catalysts/boot/cluster/config/CatBootClusterAutoconfiguration.java
@@ -1,0 +1,14 @@
+package cc.catalysts.boot.cluster.config;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * @author Paul Klingelhuber
+ */
+@Configuration
+@ConditionalOnProperty(name = "catBootCluster.disabled", havingValue = "false", matchIfMissing = true)
+@ComponentScan(basePackageClasses = CatBootClusterAutoconfiguration.class)
+public class CatBootClusterAutoconfiguration {
+}

--- a/cat-boot-cluster/src/main/java/cc/catalysts/boot/cluster/config/ClusterMetricsConfig.java
+++ b/cat-boot-cluster/src/main/java/cc/catalysts/boot/cluster/config/ClusterMetricsConfig.java
@@ -1,0 +1,55 @@
+package cc.catalysts.boot.cluster.config;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.actuate.autoconfigure.ExportMetricWriter;
+import org.springframework.boot.actuate.endpoint.MetricReaderPublicMetrics;
+import org.springframework.boot.actuate.endpoint.PublicMetrics;
+import org.springframework.boot.actuate.metrics.aggregate.AggregateMetricReader;
+import org.springframework.boot.actuate.metrics.export.MetricExportProperties;
+import org.springframework.boot.actuate.metrics.reader.MetricReader;
+import org.springframework.boot.actuate.metrics.repository.redis.RedisMetricRepository;
+import org.springframework.boot.actuate.metrics.writer.MetricWriter;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+
+/**
+ * Exports metrics to redis and even provides aggregate counts of all running instances.
+ *
+ * @author Paul Klingelhuber
+ */
+@Configuration
+@EnableConfigurationProperties
+@ConditionalOnProperty(name = "clustermetrics.disabled", havingValue = "false", matchIfMissing = true)
+public class ClusterMetricsConfig {
+
+    @Autowired
+    RedisConnectionFactory redisConnectionFactory;
+
+    @Autowired
+    private MetricExportProperties export;
+
+    @Bean
+    @ExportMetricWriter
+    public MetricWriter metricWriter(MetricExportProperties export) {
+        return new RedisMetricRepository(redisConnectionFactory,
+                export.getRedis().getPrefix(), export.getRedis().getKey());
+    }
+
+    @Bean
+    public PublicMetrics metricsAggregate() {
+        return new MetricReaderPublicMetrics(aggregatesMetricReader());
+    }
+
+    private MetricReader globalMetricsForAggregation() {
+        return new RedisMetricRepository(this.redisConnectionFactory,
+                this.export.getRedis().getAggregatePrefix(), this.export.getRedis().getKey());
+    }
+
+    private MetricReader aggregatesMetricReader() {
+        AggregateMetricReader repository = new AggregateMetricReader(globalMetricsForAggregation());
+        return repository;
+    }
+}

--- a/cat-boot-cluster/src/main/java/cc/catalysts/boot/cluster/config/SpringSessionConfig.java
+++ b/cat-boot-cluster/src/main/java/cc/catalysts/boot/cluster/config/SpringSessionConfig.java
@@ -1,0 +1,115 @@
+package cc.catalysts.boot.cluster.config;
+
+
+import cc.catalysts.boot.cluster.config.session.InvalidClassExceptionSafeRepository;
+import org.springframework.boot.actuate.metrics.CounterService;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.data.redis.connection.jedis.JedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.session.ExpiringSession;
+import org.springframework.session.SessionRepository;
+import org.springframework.session.data.redis.RedisOperationsSessionRepository;
+import org.springframework.session.data.redis.config.annotation.web.http.EnableRedisHttpSession;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import redis.clients.jedis.JedisShardInfo;
+import redis.clients.jedis.Protocol;
+
+/**
+ * Session clustering support via redis. Configures the redis session timeout via the
+ * <code>server.session-timeout</code> value.
+ *
+ * @author Paul Klingelhuber
+ */
+@Configuration
+@EnableRedisHttpSession
+public class SpringSessionConfig {
+
+    /**
+     * reconfigure session-timeout in clustered mode so it matches the session-timeout of non-clustered mode
+     */
+    @Primary
+    @Bean
+    public SessionRepository sessionRepository(RedisTemplate<String, ExpiringSession> sessionRedisTemplate,
+                                               CounterService counterService, ServerConfig serverConfig) {
+        RedisOperationsSessionRepository sessionRepository = new RedisOperationsSessionRepository(sessionRedisTemplate);
+        sessionRepository.setDefaultMaxInactiveInterval(serverConfig.getSessionTimeout());
+        // to prevent issues when upgrading spring-security versions (incompatible SecurityContext serialization)
+        //  wrap the sessionRepository again
+        return new InvalidClassExceptionSafeRepository(sessionRepository, sessionRedisTemplate, counterService);
+    }
+
+    @ConditionalOnMissingBean(JedisConnectionFactory.class)
+    @Bean
+    public JedisConnectionFactory connectionFactory(RedisConfig config) {
+        if (StringUtils.isEmpty(config.getHost()) || StringUtils.isEmpty(config.getPort())) {
+            throw new IllegalStateException("missing required redis configuraiton properties " +
+                    "(spring.redis.host or spring.redis.port)");
+        }
+        JedisShardInfo shardInfo = new JedisShardInfo(config.host, config.port, "redisServer");
+        shardInfo.setPassword(config.password);
+        return new JedisConnectionFactory(shardInfo);
+    }
+
+    @Bean
+    StringRedisTemplate stringRedisTemplate(JedisConnectionFactory jedisConnectionFactory) {
+        return new StringRedisTemplate(jedisConnectionFactory);
+    }
+
+    @Component
+    @ConfigurationProperties(prefix = "server")
+    static class ServerConfig {
+        private static final int DEFAULT_SESSION_TIMEOUT = 3600;
+
+        private Integer sessionTimeout = DEFAULT_SESSION_TIMEOUT;
+
+        public Integer getSessionTimeout() {
+            return sessionTimeout;
+        }
+
+        public void setSessionTimeout(Integer sessionTimeout) {
+            this.sessionTimeout = sessionTimeout;
+        }
+    }
+
+    /**
+     * simple configuration for sessions
+     */
+    @Component
+    @ConfigurationProperties(prefix = "spring.redis")
+    static class RedisConfig {
+        private String host = "localhost";
+        private int port = Protocol.DEFAULT_PORT;
+        private String password;
+
+        public String getHost() {
+            return host;
+        }
+
+        public void setHost(String host) {
+            this.host = host;
+        }
+
+        public int getPort() {
+            return port;
+        }
+
+        public void setPort(int port) {
+            this.port = port;
+        }
+
+        public String getPassword() {
+            return password;
+        }
+
+        public void setPassword(String password) {
+            this.password = password;
+        }
+    }
+
+}

--- a/cat-boot-cluster/src/main/java/cc/catalysts/boot/cluster/config/session/InvalidClassExceptionSafeRepository.java
+++ b/cat-boot-cluster/src/main/java/cc/catalysts/boot/cluster/config/session/InvalidClassExceptionSafeRepository.java
@@ -1,0 +1,64 @@
+package cc.catalysts.boot.cluster.config.session;
+
+import org.slf4j.Logger;
+import org.springframework.boot.actuate.metrics.CounterService;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.SerializationException;
+import org.springframework.session.ExpiringSession;
+import org.springframework.session.SessionRepository;
+
+import static org.slf4j.LoggerFactory.getLogger;
+
+/**
+ * <p>
+ * Wrapper session-repository that deletes session objects which can no longer be deserialized
+ * adapted from: https://github.com/spring-projects/spring-session/issues/280
+ * </p>
+ * <p>
+ * This helps mitigate issues when by upgrading libraries (such as spring-security) the compatability of cluster
+ * serialization gets broken.
+ * In that case your users will simply be logged out but there won't be any more severe problems.
+ * </p>
+ *
+ * @author Paul Klingelhuber
+ */
+public class InvalidClassExceptionSafeRepository<S extends ExpiringSession> implements SessionRepository<S> {
+    private static final Logger LOG = getLogger(InvalidClassExceptionSafeRepository.class);
+    private final SessionRepository<S> repository;
+    private final RedisTemplate<String, ExpiringSession> sessionRedisTemplate;
+    private final CounterService counterService;
+    static final String BOUNDED_HASH_KEY_PREFIX = "spring:session:sessions:";
+
+    public InvalidClassExceptionSafeRepository(SessionRepository<S> repository,
+                                               RedisTemplate<String, ExpiringSession> sessionRedisTemplate,
+                                               CounterService counterService) {
+        this.repository = repository;
+        this.sessionRedisTemplate = sessionRedisTemplate;
+        this.counterService = counterService;
+    }
+
+    public S getSession(String id) {
+        try {
+            return repository.getSession(id);
+        } catch (SerializationException e) {
+            LOG.info("deleting non-deserializable session with key {}", id);
+            // NOTE: deleting directly via redis instead of template since the repository.delete method would
+            //  run into the same serializationissue again
+            sessionRedisTemplate.delete(BOUNDED_HASH_KEY_PREFIX + id);
+            counterService.increment("meter.cat.boot.session.deleteAfterDeserializationError");
+            return null;
+        }
+    }
+
+    public S createSession() {
+        return repository.createSession();
+    }
+
+    public void save(S session) {
+        repository.save(session);
+    }
+
+    public void delete(String id) {
+        repository.delete(id);
+    }
+}

--- a/cat-boot-cluster/src/main/resources/META-INF/spring.factories
+++ b/cat-boot-cluster/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,2 @@
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
+cc.catalysts.boot.cluster.config.CatBootClusterAutoconfiguration

--- a/cat-boot-cluster/src/test/java/cc/catalysts/boot/cluster/CatBootClusterConfigIntegrationTests.java
+++ b/cat-boot-cluster/src/test/java/cc/catalysts/boot/cluster/CatBootClusterConfigIntegrationTests.java
@@ -1,0 +1,72 @@
+package cc.catalysts.boot.cluster;
+
+import cc.catalysts.boot.cluster.config.CatBootClusterAutoconfiguration;
+import cc.catalysts.boot.cluster.config.session.InvalidClassExceptionSafeRepository;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.actuate.metrics.CounterService;
+import org.springframework.boot.actuate.metrics.export.MetricExportProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.jedis.JedisConnection;
+import org.springframework.data.redis.connection.jedis.JedisConnectionFactory;
+import org.springframework.session.SessionRepository;
+import org.springframework.session.data.redis.RedisOperationsSessionRepository;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.util.Assert;
+
+/**
+ * @author Paul Klingelhuber
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@WebAppConfiguration
+@TestPropertySource
+@ContextConfiguration(classes = {CatBootClusterConfigIntegrationTests.Config.class, CatBootClusterAutoconfiguration.class})
+public class CatBootClusterConfigIntegrationTests {
+
+    @Autowired
+    SessionRepository sessionRepository;
+
+    @Test
+    public void testSessionRepository() {
+        Assert.isTrue(sessionRepository instanceof InvalidClassExceptionSafeRepository);
+    }
+
+    @Test
+    public void testSessionTimeout() {
+        RedisOperationsSessionRepository innerRepository = (RedisOperationsSessionRepository)ReflectionTestUtils
+                .getField(sessionRepository, "repository");
+        Integer sessionTimeout = (Integer) ReflectionTestUtils.getField(innerRepository, "defaultMaxInactiveInterval");
+        Assert.isTrue(Integer.valueOf(12345).equals(sessionTimeout));
+    }
+
+    @Configuration
+    public static class Config {
+        @Bean
+        public MetricExportProperties metricExportProperties() {
+            MetricExportProperties metricExportProperties = new MetricExportProperties();
+            metricExportProperties.setUpDefaults();
+            return metricExportProperties;
+        }
+
+        @Bean
+        public CounterService counterService() {
+            return Mockito.mock(CounterService.class);
+        }
+
+        @Bean
+        public JedisConnectionFactory jedisConnectionFactory() {
+            JedisConnectionFactory mock = Mockito.mock(JedisConnectionFactory.class);
+            Mockito.when(mock.getConnection()).thenReturn(Mockito.mock(JedisConnection.class));
+            return mock;
+        }
+
+    }
+
+}

--- a/cat-boot-cluster/src/test/resources/cc/catalysts/boot/cluster/CatBootClusterConfigIntegrationTests.properties
+++ b/cat-boot-cluster/src/test/resources/cc/catalysts/boot/cluster/CatBootClusterConfigIntegrationTests.properties
@@ -1,0 +1,1 @@
+server.session-timeout = 12345

--- a/settings.gradle
+++ b/settings.gradle
@@ -3,4 +3,4 @@ include 'cat-boot-i18n'
 include 'cat-boot-i18n-angular'
 include 'cat-boot-report-pdf'
 include 'cat-boot-thymeleaf'
-
+include 'cat-boot-cluster'


### PR DESCRIPTION
Redis clustering config, example application that is fully cluster enabled (session shared via redis)

```java
import org.springframework.boot.SpringApplication;
import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
import org.springframework.context.annotation.Configuration;
import org.springframework.web.bind.annotation.RequestMapping;
import org.springframework.web.bind.annotation.RestController;

import javax.servlet.http.HttpSession;
import java.util.Objects;

@Configuration
@RestController
@EnableAutoConfiguration
public class Main {

    public static void main(String[] args) {
        SpringApplication.run(Main.class, args);
    }

    @RequestMapping("/")
    public Object testAction(HttpSession httpSession) {
        String value = Objects.toString(httpSession.getAttribute("foo"), "");
        httpSession.setAttribute("foo", value + "x");
        return value;
    }

}
```

corresponding `build.gradle`
```
buildscript {
    dependencies {
        classpath("org.springframework.boot:spring-boot-gradle-plugin:1.3.2.RELEASE")
    }
}

buildscript {
    repositories {
        jcenter()
        maven {
            url "http://repo.spring.io/snapshot"
        }
        maven {
            url "http://repo.spring.io/milestone"
        }
    }
}
apply plugin: 'java'
apply plugin: 'spring-boot'

dependencies {
    compile("org.springframework.boot:spring-boot-starter-web")

    runtime('cc.catalysts.boot:cat-boot-cluster:' + catBootVersion)
}

repositories {
    jcenter()
    maven {
        url 'http://repo.spring.io/snapshot'
    }
}
```
