### PR TITLE
reorganize the flow of the report builder

### DIFF
--- a/cat-boot-report-pdf/src/main/java/cc/catalysts/boot/report/pdf/PdfReportBuilder.java
+++ b/cat-boot-report-pdf/src/main/java/cc/catalysts/boot/report/pdf/PdfReportBuilder.java
@@ -4,6 +4,7 @@ import cc.catalysts.boot.report.pdf.config.PdfPageLayout;
 import cc.catalysts.boot.report.pdf.config.PdfTextStyle;
 import cc.catalysts.boot.report.pdf.elements.ReportElement;
 import cc.catalysts.boot.report.pdf.utils.PositionOfStaticElements;
+import org.apache.pdfbox.pdmodel.PDDocument;
 import org.springframework.core.io.Resource;
 
 import java.io.IOException;
@@ -44,6 +45,8 @@ public interface PdfReportBuilder {
     ReportTableBuilder startTable();
 
     PdfReport buildReport(String fileName, PdfPageLayout pageConfig, Resource templateResource) throws IOException;
+
+    PdfReport buildReport(String fileName, PdfPageLayout pageConfig, Resource templateResource, PDDocument document) throws IOException;
 
     PdfReportBuilder addImage(Resource resource, float width, float height) throws IOException;
 }

--- a/cat-boot-report-pdf/src/main/java/cc/catalysts/boot/report/pdf/config/PdfTextStyle.java
+++ b/cat-boot-report-pdf/src/main/java/cc/catalysts/boot/report/pdf/config/PdfTextStyle.java
@@ -1,6 +1,7 @@
 package cc.catalysts.boot.report.pdf.config;
 
 import org.apache.pdfbox.pdmodel.font.PDFont;
+import org.apache.pdfbox.pdmodel.font.PDTrueTypeFont;
 import org.apache.pdfbox.pdmodel.font.PDType1Font;
 import org.springframework.util.Assert;
 
@@ -11,6 +12,12 @@ public class PdfTextStyle {
     private int fontSize;
     private PDFont font;
     private Color color;
+
+    public PdfTextStyle(int fontSize, PDFont defaultFont, Color color) {
+        this.fontSize = fontSize;
+        this.font = defaultFont;
+        this.color = color;
+    }
 
     public PdfTextStyle(int fontSize, PDType1Font defaultFont, Color color) {
         this.fontSize = fontSize;

--- a/cat-boot-report-pdf/src/main/java/cc/catalysts/boot/report/pdf/impl/PdfReportBuilderImpl.java
+++ b/cat-boot-report-pdf/src/main/java/cc/catalysts/boot/report/pdf/impl/PdfReportBuilderImpl.java
@@ -147,8 +147,12 @@ class PdfReportBuilderImpl implements PdfReportBuilder {
 
     @Override
     public PdfReport buildReport(String fileName, PdfPageLayout pageConfig, Resource templateResource) throws IOException {
+        return buildReport(fileName, pageConfig, templateResource, new PDDocument());
+    }
+
+    public PdfReport buildReport(String fileName, PdfPageLayout pageConfig, Resource templateResource, PDDocument document) throws IOException {
         PdfReportStructure report = this.buildReport(pageConfig);
-        PDDocument document = new PdfReportGenerator().generate(pageConfig, templateResource, report);
+        document = new PdfReportGenerator().generate(pageConfig, templateResource, report, document);
         return new PdfReport(fileName, document);
     }
 

--- a/cat-boot-report-pdf/src/main/java/cc/catalysts/boot/report/pdf/impl/PdfReportGenerator.java
+++ b/cat-boot-report-pdf/src/main/java/cc/catalysts/boot/report/pdf/impl/PdfReportGenerator.java
@@ -32,17 +32,20 @@ class PdfReportGenerator {
         page.close();
     }
 
+    public PDDocument generate(PdfPageLayout pageConfig, Resource templateResource, PdfReportStructure report) throws IOException {
+        return generate(pageConfig, templateResource, report, new PDDocument());
+    }
+
     /**
      * @param pageConfig page config
      * @param report     the report to print
      * @return the printed PdfBox document
      * @throws java.io.IOException
      */
-    public PDDocument generate(PdfPageLayout pageConfig, Resource templateResource, PdfReportStructure report) throws IOException {
+    public PDDocument generate(PdfPageLayout pageConfig, Resource templateResource, PdfReportStructure report, PDDocument document) throws IOException {
 
         PrintData printData = new PrintData(templateResource, pageConfig);
         PrintCursor cursor = new PrintCursor();
-        PDDocument document = new PDDocument();
 
         breakPage(document, cursor, printData);
         float maxWidth = pageConfig.getUsableWidth();


### PR DESCRIPTION
the PDDocument is now instantiated much earlier (i.e. can be passed to the
builder directly). existing APIs should not be affected.