### PR TITLE
fix "PDF Document not closed" warnings that sometimes occured

### DIFF
--- a/cat-boot-report-pdf/src/main/java/cc/catalysts/boot/report/pdf/PdfReport.java
+++ b/cat-boot-report-pdf/src/main/java/cc/catalysts/boot/report/pdf/PdfReport.java
@@ -1,24 +1,47 @@
 package cc.catalysts.boot.report.pdf;
 
+import cc.catalysts.boot.report.pdf.impl.DocumentWithResources;
 import org.apache.pdfbox.pdmodel.PDDocument;
+import org.slf4j.Logger;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+import static org.slf4j.LoggerFactory.getLogger;
 
 /**
  * @author Klaus Lehner
  */
-public class PdfReport {
-    private final String fileName;
-    private final PDDocument document;
+public class PdfReport implements AutoCloseable {
+    private static final Logger LOG = getLogger(PdfReport.class);
 
-    public PdfReport(String fileName, PDDocument document) {
+    private final String fileName;
+    private final DocumentWithResources documentWithResources;
+
+    public PdfReport(String fileName, DocumentWithResources documentWithResources) {
         this.fileName = fileName;
-        this.document = document;
+        this.documentWithResources = documentWithResources;
     }
 
     public String getFileName() {
         return fileName;
     }
 
+    /**
+     * Prefer using saveAndClose whenever possible.
+     * Alternatively call close() yourself to close any tracked resource dependencies.
+     */
     public PDDocument getDocument() {
-        return document;
+        return documentWithResources.getDocument();
     }
+
+    public void saveAndClose(OutputStream outputStream) throws IOException {
+        documentWithResources.saveAndClose(outputStream);
+    }
+
+    @Override
+    public void close() {
+        documentWithResources.close();
+    }
+
 }

--- a/cat-boot-report-pdf/src/main/java/cc/catalysts/boot/report/pdf/elements/ReportRichTextBox.java
+++ b/cat-boot-report-pdf/src/main/java/cc/catalysts/boot/report/pdf/elements/ReportRichTextBox.java
@@ -10,6 +10,8 @@ import org.springframework.util.StringUtils;
  */
 public class ReportRichTextBox extends ReportTextBox {
 
+    private static final String LINE_SEPARATOR = System.getProperty("line.separator");
+
     private String boldFontStyle;
     private String italicFontStyle;
 
@@ -62,7 +64,7 @@ public class ReportRichTextBox extends ReportTextBox {
             if (currHeight + getFirstSegmentHeight(allowedWidth) <= allowedHeight) {
                 String[] split = split(allowedWidth, currText);
                 sb.append(split[0].trim());
-                sb.append(System.getProperty("line.separator"));
+                sb.append(LINE_SEPARATOR);
                 currText = split[1];
                 currHeight += getFirstSegmentHeight(allowedWidth) + lineDistance;
             } else {

--- a/cat-boot-report-pdf/src/main/java/cc/catalysts/boot/report/pdf/elements/ReportTable.java
+++ b/cat-boot-report-pdf/src/main/java/cc/catalysts/boot/report/pdf/elements/ReportTable.java
@@ -22,7 +22,6 @@ public class ReportTable implements ReportElement {
     private static final boolean DEFAULT_BORDER = false;
     private static final float DEFAULT_CELL_PADDING_LEFT_RIGHT = 2;
     private static final float DEFAULT_CELL_PADDING_TOP_BOTTOM = 2;
-    private static final int BORDER_Y_DELTA = 0;
     private final PdfStyleSheet pdfStyleSheet;
 
     private float[] cellWidths;
@@ -281,7 +280,8 @@ public class ReportTable implements ReportElement {
     @Override
     public float getFirstSegmentHeight(float allowedWidth) {
         if (elements != null && elements.length > 0) {
-            return border ? getFirstSegmentHeightFromLine(elements[0], allowedWidth) + BORDER_Y_DELTA : getFirstSegmentHeightFromLine(elements[0], allowedWidth);
+            final float firstSegmentHeightFromLine = getFirstSegmentHeightFromLine(elements[0], allowedWidth);
+            return firstSegmentHeightFromLine + pdfStyleSheet.getLineDistance();
         } else {
             return 0;
         }
@@ -291,7 +291,7 @@ public class ReportTable implements ReportElement {
         float maxHeight = 0f;
         for (int i = 0; i < line.length; i++) {
             if (line[i] != null) {
-                maxHeight = Math.max(maxHeight, line[i].getFirstSegmentHeight(cellWidths[i] * allowedWidth - cellPaddingX * 2));
+                maxHeight = Math.max(maxHeight, line[i].getFirstSegmentHeight(getAllowedNetColumnWidth(allowedWidth, i)));
             }
         }
         return maxHeight + 2 * cellPaddingY;
@@ -395,18 +395,18 @@ public class ReportTable implements ReportElement {
             if (enableExtraSplitting) {
                 splittable = true;
                 for (int j = 0; j < elements[lineIndex].length; j++) {
-                    if (!elements[lineIndex][j].isSplitable() || currentHeight + elements[lineIndex][j].getFirstSegmentHeight(cellWidths[j] * allowedWidth - cellPaddingX * 2) + 2 * cellPaddingY >= allowedHeight) {
+                    if (!elements[lineIndex][j].isSplitable() || currentHeight + elements[lineIndex][j].getFirstSegmentHeight(getAllowedNetColumnWidth(allowedWidth, j)) + 2 * cellPaddingY >= allowedHeight) {
                         splittable = false;
                     }
                 }
 
                 if (splittable) {
                     for (int j = 0; j < elements[lineIndex].length; j++) {
-                        if (elements[lineIndex][j].getHeight(cellWidths[j] * allowedWidth - cellPaddingX * 2) + currentHeight < allowedHeight) {
+                        if (elements[lineIndex][j].getHeight(getAllowedNetColumnWidth(allowedWidth, j)) + currentHeight < allowedHeight) {
                             extraRows[0][j] = elements[lineIndex][j];
                             extraRows[1][j] = new ReportTextBox(pdfStyleSheet.getBodyText(), pdfStyleSheet.getLineDistance(), "");
                         } else {
-                            ReportElement[] extraSplit = elements[lineIndex][j].split(cellWidths[j] * allowedWidth - cellPaddingX * 2, allowedHeight - currentHeight - 2 * cellPaddingY);
+                            ReportElement[] extraSplit = elements[lineIndex][j].split(getAllowedNetColumnWidth(allowedWidth, j), allowedHeight - currentHeight - 2 * cellPaddingY);
                             extraRows[0][j] = extraSplit[0];
                             extraRows[1][j] = extraSplit[1];
                         }
@@ -437,7 +437,7 @@ public class ReportTable implements ReportElement {
             for (lineIndex = 1; lineIndex < elements.length; lineIndex++)
                 next[lineIndex] = elements[lineIndex];
             for (lineIndex = 0; lineIndex < elements[0].length; lineIndex++) {
-                ReportElement[] splits = elements[0][lineIndex].split(cellWidths[lineIndex] * allowedWidth - cellPaddingX * 2, allowedHeight - 2 * cellPaddingY);
+                ReportElement[] splits = elements[0][lineIndex].split(getAllowedNetColumnWidth(allowedWidth, lineIndex), allowedHeight - 2 * cellPaddingY);
                 if (splits[0] != null)
                     first[0][lineIndex] = splits[0];
                 else

--- a/cat-boot-report-pdf/src/main/java/cc/catalysts/boot/report/pdf/elements/ReportTextBox.java
+++ b/cat-boot-report-pdf/src/main/java/cc/catalysts/boot/report/pdf/elements/ReportTextBox.java
@@ -19,6 +19,8 @@ import java.util.Map;
  */
 public class ReportTextBox implements ReportElement {
 
+    private static final String LINE_SEPARATOR = System.getProperty("line.separator");
+
     protected PdfTextStyle textConfig;
     protected String text;
     protected final float lineDistance;
@@ -58,6 +60,10 @@ public class ReportTextBox implements ReportElement {
         int height = 0;
         String currText = text;
         while (currText != null) {
+            if  (height > 0 && "".equals(currText)) {
+                // a trailing empty string does not add any height
+                break;
+            }
             String[] split = split(allowedWidth, currText);
             height += getFirstSegmentHeight(allowedWidth) + lineDistance;
             if (split[1] != null && split[1].equals(currText)) {
@@ -96,13 +102,13 @@ public class ReportTextBox implements ReportElement {
     @Override
     public ReportElement[] split(float allowedWidth, float allowedHeight) {
         StringBuilder sb = new StringBuilder();
-        float currHeight = getFirstSegmentHeight(allowedWidth) + lineDistance;
+        float currHeight = 0;
         String currText = text;
         while (!StringUtils.isEmpty(currText) && currHeight <= allowedHeight) {
             if (currHeight + getFirstSegmentHeight(allowedWidth) <= allowedHeight) {
                 String[] split = split(allowedWidth, currText);
                 sb.append(split[0].trim());
-                sb.append(System.getProperty("line.separator"));
+                sb.append(LINE_SEPARATOR);
                 currText = split[1];
                 currHeight += getFirstSegmentHeight(allowedWidth) + lineDistance;
             } else {

--- a/cat-boot-report-pdf/src/main/java/cc/catalysts/boot/report/pdf/impl/DocumentWithResources.java
+++ b/cat-boot-report-pdf/src/main/java/cc/catalysts/boot/report/pdf/impl/DocumentWithResources.java
@@ -1,0 +1,65 @@
+package cc.catalysts.boot.report.pdf.impl;
+
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.slf4j.Logger;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.slf4j.LoggerFactory.getLogger;
+
+public class DocumentWithResources implements AutoCloseable {
+    private static final Logger LOG = getLogger(DocumentWithResources.class);
+
+    private final PDDocument document;
+
+    private boolean isClosed = false;
+
+    /**
+     * resources that need to be closed after the document has been written.
+     */
+    private final List<Closeable> resourceDependencies = new ArrayList<>();
+
+    public DocumentWithResources(PDDocument document) {
+        this.document = document;
+    }
+
+    public PDDocument getDocument() {
+        return document;
+    }
+
+    public void addResourceDependency(Closeable resourceDependency) {
+        this.resourceDependencies.add(resourceDependency);
+    }
+
+    public void saveAndClose(OutputStream outputStream) throws IOException {
+        try {
+            document.save(outputStream);
+        } finally {
+            this.close();
+        }
+    }
+
+    @Override
+    public void close() {
+        if (isClosed) {
+            return;
+        }
+        try {
+            document.close();
+        } catch (final Exception e) {
+            LOG.warn("Exception occured while trying to close the document: {}", e.getMessage(), e);
+        }
+        for (Closeable dependency : resourceDependencies) {
+            try {
+                dependency.close();
+            } catch (Exception e) {
+                LOG.warn("Exception occured while trying to close resource dependency: {}", e.getMessage(), e);
+            }
+        }
+        isClosed = true;
+    }
+}

--- a/cat-boot-report-pdf/src/main/java/cc/catalysts/boot/report/pdf/impl/PdfReportBuilderImpl.java
+++ b/cat-boot-report-pdf/src/main/java/cc/catalysts/boot/report/pdf/impl/PdfReportBuilderImpl.java
@@ -3,8 +3,19 @@ package cc.catalysts.boot.report.pdf.impl;
 import cc.catalysts.boot.report.pdf.PdfReport;
 import cc.catalysts.boot.report.pdf.PdfReportBuilder;
 import cc.catalysts.boot.report.pdf.ReportTableBuilder;
-import cc.catalysts.boot.report.pdf.config.*;
-import cc.catalysts.boot.report.pdf.elements.*;
+import cc.catalysts.boot.report.pdf.config.DefaultPdfStyleSheet;
+import cc.catalysts.boot.report.pdf.config.PdfFont;
+import cc.catalysts.boot.report.pdf.config.PdfPageLayout;
+import cc.catalysts.boot.report.pdf.config.PdfStyleSheet;
+import cc.catalysts.boot.report.pdf.config.PdfTextStyle;
+import cc.catalysts.boot.report.pdf.elements.ReportElement;
+import cc.catalysts.boot.report.pdf.elements.ReportElementStatic;
+import cc.catalysts.boot.report.pdf.elements.ReportImage;
+import cc.catalysts.boot.report.pdf.elements.ReportLink;
+import cc.catalysts.boot.report.pdf.elements.ReportPadding;
+import cc.catalysts.boot.report.pdf.elements.ReportPageBreak;
+import cc.catalysts.boot.report.pdf.elements.ReportTable;
+import cc.catalysts.boot.report.pdf.elements.ReportTextBox;
 import cc.catalysts.boot.report.pdf.utils.PositionOfStaticElements;
 import cc.catalysts.boot.report.pdf.utils.ReportAlignType;
 import org.apache.pdfbox.pdmodel.PDDocument;
@@ -139,13 +150,13 @@ class PdfReportBuilderImpl implements PdfReportBuilder {
 
     @Override
     public PdfReport buildReport(String fileName, PdfPageLayout pageConfig, Resource templateResource) throws IOException {
-        return buildReport(fileName, pageConfig, templateResource, new PDDocument());
+        return buildReport(fileName, pageConfig, templateResource, document);
     }
 
     public PdfReport buildReport(String fileName, PdfPageLayout pageConfig, Resource templateResource, PDDocument document) throws IOException {
         PdfReportStructure report = this.buildReport(pageConfig);
-        new PdfReportGenerator().generate(pageConfig, templateResource, report, document);
-        return new PdfReport(fileName, document);
+        final DocumentWithResources documentWithResources = new PdfReportGenerator().generate(pageConfig, templateResource, report, document);
+        return new PdfReport(fileName, documentWithResources);
     }
 
     @Override

--- a/cat-boot-report-pdf/src/main/java/cc/catalysts/boot/report/pdf/impl/PdfReportFilePrinter.java
+++ b/cat-boot-report-pdf/src/main/java/cc/catalysts/boot/report/pdf/impl/PdfReportFilePrinter.java
@@ -3,7 +3,9 @@ package cc.catalysts.boot.report.pdf.impl;
 import cc.catalysts.boot.report.pdf.PdfReport;
 import cc.catalysts.boot.report.pdf.PdfReportPrinter;
 
+import java.io.BufferedOutputStream;
 import java.io.File;
+import java.io.FileOutputStream;
 import java.io.IOException;
 
 /**
@@ -16,8 +18,8 @@ public final class PdfReportFilePrinter implements PdfReportPrinter<File> {
             throw new IllegalArgumentException(directory + " is no directory ");
         }
         File outputFile = new File(directory, report.getFileName());
-        report.getDocument().save(outputFile);
-        report.getDocument().close();
+        report.saveAndClose(new BufferedOutputStream(new FileOutputStream(outputFile)));
+        report.close();
     }
 
 }

--- a/cat-boot-report-pdf/src/main/java/cc/catalysts/boot/report/pdf/impl/PdfReportHttpResponsePrinter.java
+++ b/cat-boot-report-pdf/src/main/java/cc/catalysts/boot/report/pdf/impl/PdfReportHttpResponsePrinter.java
@@ -15,8 +15,7 @@ public final class PdfReportHttpResponsePrinter implements PdfReportPrinter<Http
         response.setContentType("application/pdf");
         response.setHeader("Content-disposition", "attachment; filename=" + report.getFileName());
 
-        report.getDocument().save(response.getOutputStream());
-        report.getDocument().close();
+        report.saveAndClose(response.getOutputStream());
         response.getOutputStream().close();
     }
 

--- a/cat-boot-report-pdf/src/test/java/cc/catalysts/boot/report/pdf/impl/Demo2Test.java
+++ b/cat-boot-report-pdf/src/test/java/cc/catalysts/boot/report/pdf/impl/Demo2Test.java
@@ -45,11 +45,7 @@ public class Demo2Test {
         styleSheet.setBodyText(new PdfTextStyle(10, PdfFont.getFont("Noto Sans"), BLACK, "regular"));
         styleSheet.setTableBodyText(new PdfTextStyle(10, PdfFont.getFont("Noto Sans"), BLACK, "regular"));
 
-        BufferedImage img = null;
-        try {
-            img = ImageIO.read(new ClassPathResource("/github_icon.png").getInputStream());
-        } catch (IOException e) {
-        }
+        BufferedImage img = ImageIO.read(new ClassPathResource("/github_icon.png").getInputStream());
 
         ReportTable sampleTable = new ReportTableBuilderImpl(styleSheet, null)
                 .addColumn("1", 1).addColumn("2", 3).createRow().withValues("z1", "z2").build();
@@ -123,7 +119,6 @@ public class Demo2Test {
             Assert.assertTrue(target.mkdirs());
         }
         pdfReportFilePrinter.print(pdfReport, target);
-
     }
 
 }

--- a/properties.gradle
+++ b/properties.gradle
@@ -1,5 +1,5 @@
 ext.cbGroup = 'cc.catalysts.boot'
-ext.cbVersion = '1.1.3'
+ext.cbVersion = '1.1.4'
 ext.cbWebsite = 'https://github.com/Catalysts/cat-boot'
 ext.cbTracker = 'https://github.com/Catalysts/cat-boot/issues'
 ext.cbGit = 'https://github.com/Catalysts/cat-boot.git'


### PR DESCRIPTION
fix "PDF Document not closed" warnings that sometimes occured when generating PDFs

add parallelism test to expose any potential raceconditions